### PR TITLE
Add minimumSegmentWidth property that can be set if the text is very …

### DIFF
--- a/HMSegmentedControl/HMSegmentedControl.h
+++ b/HMSegmentedControl/HMSegmentedControl.h
@@ -118,6 +118,14 @@ typedef NS_ENUM(NSInteger, HMSegmentedControlType) {
 @property (nonatomic, assign) CGFloat verticalDividerWidth;
 
 /**
+ Minimum width of segments segments that is used when `segmentWidthStyle` is set to HMSegmentedControlSegmentWidthStyleDynamic.
+ 
+ Default is `0.0f`
+ */
+@property (nonatomic, assign) CGFloat minimumSegmentWidth;
+
+
+/**
  Specifies the style of the control
  
  Default is `HMSegmentedControlTypeText`

--- a/HMSegmentedControl/HMSegmentedControl.m
+++ b/HMSegmentedControl/HMSegmentedControl.m
@@ -188,6 +188,8 @@
     
     self.contentMode = UIViewContentModeRedraw;
     
+    self.minimumSegmentWidth =0.0;
+    
     _enableSelectEffectForSingleSegment = NO;
     _centerWhenNecessary = YES;
     _makeHorizonSpaceEqualEqualityWhenJustHasTwoSegments = YES;
@@ -784,6 +786,7 @@
         
         [self.sectionTitles enumerateObjectsUsingBlock:^(id titleString, NSUInteger idx, BOOL *stop) {
             CGFloat stringWidth = [self measureTitleAtIndex:idx].width + self.segmentEdgeInset.left + self.segmentEdgeInset.right;
+            stringWidth= stringWidth<self.minimumSegmentWidth?self.minimumSegmentWidth:stringWidth;
             [mutableSegmentWidths addObject:[NSNumber numberWithFloat:stringWidth]];
         }];
         self.segmentWidthsArray = [mutableSegmentWidths copy];


### PR DESCRIPTION
…short (e.g. "1") and does not provide a proper visual segment representation.